### PR TITLE
Adds writes2.py

### DIFF
--- a/writes2.py
+++ b/writes2.py
@@ -1,0 +1,10 @@
+import os
+line = 'a' * 30000
+filename = '/tmp/fake.txt'
+
+with open(filename, 'w') as f:
+    for i in xrange(10000):
+        f.write(line)
+    f.flush()
+    os.fsync(f.fileno())
+


### PR DESCRIPTION
Adds missing `writes2.py` to the repo that’s mentioned in http://jvns.ca/blog/2015/03/15/nancy-drew-and-the-case-of-the-slow-program/

Also corrects the write-to path to be generic.
